### PR TITLE
django-tagging version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,9 @@ default['graphite']['package_names'] = {
 default['graphite']['django']['version'] = '1.5.5'
 default['graphite']['django']['root'] = '@DJANGO_ROOT@'
 
-#
+#django-tagging
+default['graphite']['django-tagging']['version'] = '0.3.1'
+
 # graphite_web
 #
 default['graphite']['web']['debug'] = 'False'

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -41,6 +41,8 @@ python_pip 'django' do
 end
 
 python_pip 'django-tagging'
+  version lazy { node['graphite']['django-tagging']['version'] }
+end
 
 python_pip 'graphite_web' do
   package_name lazy {

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -40,7 +40,7 @@ python_pip 'django' do
   version lazy { node['graphite']['django']['version'] }
 end
 
-python_pip 'django-tagging'
+python_pip 'django-tagging' do
   version lazy { node['graphite']['django-tagging']['version'] }
 end
 


### PR DESCRIPTION
modified recipes/web.rb and attributes/default.rb to add lazy version 0.3.1 for django-tagging
